### PR TITLE
Add AsterCPP project overview docs

### DIFF
--- a/docs/astercpp/architecture.md
+++ b/docs/astercpp/architecture.md
@@ -1,0 +1,23 @@
+# Project Architecture
+
+Below is a brief overview of the directory layout used inside the
+[AsterCPP](https://github.com/redpropulsion/AsterCPP/) repository.
+It should help new contributors find the relevant components quickly.
+
+```
+AsterCPP/
+├─ boards/        # configuration files and startup code for specific boards
+├─ cmake/         # helper CMake scripts
+├─ include/       # public header files
+├─ src/           # C++ source code
+├─ tests/         # unit tests and integration tests
+└─ tools/         # additional scripts used during development
+```
+
+The `src` folder groups the source files by feature:
+
+- `core/` – low level services and RTOS integration
+- `drivers/` – peripherals such as sensors and communication interfaces
+- `app/` – high level application logic
+
+This structure allows the code to scale as new boards and features are added.

--- a/docs/astercpp/development.md
+++ b/docs/astercpp/development.md
@@ -1,0 +1,21 @@
+# Development workflow
+
+The project uses CMake to generate build files for the desired platform.
+In most cases you only need a modern C++ compiler and the Arm GNU toolchain
+when targeting microcontrollers.
+
+Typical steps to build the firmware from the command line:
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Unit tests can be executed with CTest once the build directory is configured:
+
+```bash
+ctest --test-dir build
+```
+
+Documentation is produced with Doxygen and published automatically
+when changes are pushed to the main branch.

--- a/docs/astercpp/index.md
+++ b/docs/astercpp/index.md
@@ -1,0 +1,14 @@
+# AsterCPP Overview
+
+AsterCPP contains the core software for the Red Propulsion boards. The repository provides
+all the firmware and utilities required to run on both airborne and ground control hardware.
+It is written in modern C++ and uses CMake to manage the build process.
+
+The codebase is divided into several modules to keep the project organised:
+
+- **HAL and Drivers** – Abstractions for microcontroller peripherals and external devices.
+- **Application Layer** – Implements mission logic and board specific behaviour.
+- **Utilities** – Common helpers, logging facilities and testing infrastructure.
+
+API documentation is generated with Doxygen and automatically published to this site.
+Refer to the navigation sidebar for the full API reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,10 @@ plugins:
   
 nav:
   - Home: index.md
+  - AsterCPP:
+    - Overview: astercpp/index.md
+    - Architecture: astercpp/architecture.md
+    - Development: astercpp/development.md
   - API Reference:
     - Overview: api/index.md
   #- Progetti:


### PR DESCRIPTION
## Summary
- document the AsterCPP codebase with an overview, architecture and development pages
- include the new docs in the MkDocs navigation

## Testing
- `mkdocs build -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842041f71908321a81f2b41e6c6d4e0